### PR TITLE
Add throttling, special throttling for cancel endpoint

### DIFF
--- a/valhalla/settings.py
+++ b/valhalla/settings.py
@@ -213,7 +213,15 @@ REST_FRAMEWORK = {
         'oauth2_provider.ext.rest_framework.OAuth2Authentication',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 50
+    'PAGE_SIZE': 50,
+    'DEFAULT_THROTTLE_CLASSES': (
+        'rest_framework.throttling.UserRateThrottle',
+        'rest_framework.throttling.ScopedRateThrottle',
+    ),
+    'DEFAULT_THROTTLE_RATES': {
+        'user': '5000/day',
+        'userrequests.cancel': '10/day'
+    }
 }
 
 CELERY_TASK_ALWAYS_EAGER = not os.getenv('CELERY_ENABLED', False)

--- a/valhalla/settings.py
+++ b/valhalla/settings.py
@@ -220,7 +220,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_THROTTLE_RATES': {
         'user': '5000/day',
-        'userrequests.cancel': '10/day'
+        'userrequests.cancel': '10/day',
+        'userrequests.validate': '10000/day'
     }
 }
 

--- a/valhalla/userrequests/viewsets.py
+++ b/valhalla/userrequests/viewsets.py
@@ -32,7 +32,7 @@ class UserRequestViewSet(viewsets.ModelViewSet):
     ordering = ('-id',)
 
     def get_throttles(self):
-        actions_to_throttle = ['cancel']
+        actions_to_throttle = ['cancel', 'validate']
         if self.action in actions_to_throttle:
             self.throttle_scope = 'userrequests.' + self.action
         return super().get_throttles()

--- a/valhalla/userrequests/viewsets.py
+++ b/valhalla/userrequests/viewsets.py
@@ -31,6 +31,12 @@ class UserRequestViewSet(viewsets.ModelViewSet):
     )
     ordering = ('-id',)
 
+    def get_throttles(self):
+        actions_to_throttle = ['cancel']
+        if self.action in actions_to_throttle:
+            self.throttle_scope = 'userrequests.' + self.action
+        return super().get_throttles()
+
     def get_queryset(self):
         if self.request.user.is_staff:
             return UserRequest.objects.all()


### PR DESCRIPTION
Implements throttling for the API. Normal and anonymous users will be limited to 5k requests/day. The cancel UserRequest endpoint will be limited to 10 requests a day. DRF does not provide a method to override throttle settings for specific actions in a ViewSet, so get_throttles is overwritten and some slight magic introduced.