### PR TITLE
Fix/telescope states endpoint

### DIFF
--- a/valhalla/common/telescope_states.py
+++ b/valhalla/common/telescope_states.py
@@ -15,116 +15,188 @@ logger = logging.getLogger(__name__)
 ES_STRING_FORMATTER = "%Y-%m-%d %H:%M:%S"
 
 
-def get_es_data(query):
-    try:
-        es = Elasticsearch([settings.ELASTICSEARCH_URL])
-    except LocationValueError:
-        logger.error('Could not find host. Make sure ELASTICSEARCH_URL is set.')
-        raise ImproperlyConfigured('ELASTICSEARCH_URL')
+class TelescopeStates(object):
+    def __init__(self, start, end, telescopes=None, sites=None, instrument_types=None):
+        self.start = start.replace(tzinfo=timezone.utc).replace(microsecond=0)
+        self.end = end.replace(tzinfo=timezone.utc).replace(microsecond=0)
+        self.instrument_types = instrument_types
+        self.available_telescopes = self._get_available_telescopes()
 
-    event_data = []
-    query_size = 10000
-    data = es.search(index="telescope_events", body=query, size=query_size, scroll='1m',
-                     _source=['timestamp', 'telescope', 'enclosure', 'site', 'type', 'reason'], sort=['timestamp'])  # noqa
-    event_data.extend(data['hits']['hits'])
-    total_events = data['hits']['total']
-    events_read = min(query_size, total_events)
-    scroll_id = data.get('_scroll_id', 0)
-    while events_read < total_events:
-        data = es.scroll(scroll_id=scroll_id, scroll='1m') # noqa
-        scroll_id = data.get('_scroll_id', 0)
-        event_data.extend(data['hits']['hits'])
-        events_read += len(data['hits']['hits'])
+        sites = list({telescope_key.site for telescope_key in self.available_telescopes}) \
+            if not sites else sites
+        telescopes = list({tk.telescope for tk in self.available_telescopes if tk.site in sites}) \
+            if not telescopes else telescopes
 
-    return event_data
+        self.event_data = self._get_es_data(sites, telescopes)
 
+    def _get_available_telescopes(self):
+        telescope_to_instruments = ConfigDB().get_instrument_types_per_telescope(only_schedulable=True)
+        if not self.instrument_types:
+            available_telescopes = telescope_to_instruments.keys()
+        else:
+            available_telescopes = [tk for tk, insts in telescope_to_instruments.items() if
+                                    any(inst in insts for inst in self.instrument_types)]
+        return available_telescopes
 
-def get_telescope_states(start, end, telescopes=None, sites=None, instrument_types=None):
-    telescope_to_instruments = ConfigDB().get_instrument_types_per_telescope(only_schedulable=True)
-    if not instrument_types:
-        available_telescopes = telescope_to_instruments.keys()
-    else:
-        available_telescopes = [tk for tk, insts in telescope_to_instruments.items() if
-                                any(inst in insts for inst in instrument_types)]
-
-    if not sites:
-        sites = list({telescope_key.site for telescope_key in available_telescopes})
-
-    if not telescopes:
-        telescopes = list({tk.telescope for tk in available_telescopes if tk.site in sites})
-
-    date_range_query = {
-        "query": {
-            "filtered": {
-                "filter": {
-                    "and": [
-                        {
-                            "range": {
-                                "timestamp": {
-                                    "gte": start.strftime(ES_STRING_FORMATTER),
-                                    "lte": end.strftime(ES_STRING_FORMATTER),
-                                    "format": "yyyy-MM-dd HH:mm:ss"
+    def _get_es_data(self, sites, telescopes):
+        date_range_query = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {
+                                "range": {
+                                    "timestamp": {
+                                        "gte": (self.start - timedelta(hours=1)).strftime(ES_STRING_FORMATTER),
+                                        "lte": self.end.strftime(ES_STRING_FORMATTER),
+                                        "format": "yyyy-MM-dd HH:mm:ss"
+                                    }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "telescope": telescopes
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "site": sites
                                 }
                             }
-                        },
-                        {
-                            "terms": {
-                                "telescope": telescopes
-                            }
-                        },
-                        {
-                            "terms": {
-                                "site": sites
-                            }
-                        }
-                    ]
+                        ]
+                    }
                 }
             }
         }
-    }
+        try:
+            es = Elasticsearch([settings.ELASTICSEARCH_URL])
+        except LocationValueError:
+            logger.error('Could not find host. Make sure ELASTICSEARCH_URL is set.')
+            raise ImproperlyConfigured('ELASTICSEARCH_URL')
 
-    event_data = get_es_data(date_range_query)
-    telescope_status = {}
-    last_event = {}
+        event_data = []
+        query_size = 10000
+        data = es.search(index="telescope_events", body=date_range_query, size=query_size, scroll='1m',
+                         _source=['timestamp', 'telescope', 'enclosure', 'site', 'type', 'reason'],
+                         sort=['site', 'enclosure', 'telescope', 'timestamp'])  # noqa
+        event_data.extend(data['hits']['hits'])
+        total_events = data['hits']['total']
+        events_read = min(query_size, total_events)
+        scroll_id = data.get('_scroll_id', 0)
+        while events_read < total_events:
+            data = es.scroll(scroll_id=scroll_id, scroll='1m') # noqa
+            scroll_id = data.get('_scroll_id', 0)
+            event_data.extend(data['hits']['hits'])
+            events_read += len(data['hits']['hits'])
+        return event_data
 
-    for events in event_data:
-        # ignore the enclosure_interlock state as it is redundant
-        if events['_source']['type'].upper() == 'ENCLOSURE_INTERLOCK':
-            continue
-        telescope_key = TelescopeKey(site=events['_source']['site'],
-                                     observatory=events['_source']['enclosure'],
-                                     telescope=events['_source']['telescope'])
-        if telescope_key in available_telescopes:
-            timestamp = datetime.strptime(events['_source']['timestamp'],
-                                          ES_STRING_FORMATTER).replace(tzinfo=timezone.utc)
-            if telescope_key not in telescope_status:
-                telescope_status[telescope_key] = []
-                last_event[telescope_key] = None
+    def _belongs_in_lump(self, event_source, lump_data, dt=60):
+        if str(lump_data['telescope']) != str(self._telescope(event_source)):
+            return False
 
-            if not last_event[telescope_key]:
-                last_event[telescope_key] = events['_source']
-            elif (last_event[telescope_key]['type'] != events['_source']['type']
-                  or last_event[telescope_key]['reason'] != events['_source']['reason']):
-                telescope_status[telescope_key].append({'telescope': str(telescope_key),
-                                                        'event_type': last_event[telescope_key]['type'],
-                                                        'event_reason': last_event[telescope_key]['reason'],
-                                                        'start': datetime.strptime(
-                                                            last_event[telescope_key]['timestamp'],
-                                                            ES_STRING_FORMATTER).replace(tzinfo=timezone.utc),
-                                                        'end': timestamp})
-                last_event[telescope_key] = events['_source']
+        time_diff = (self._es_to_datetime(event_source['timestamp']) - lump_data['latest_timestamp']).total_seconds()
 
-    for telescope_key, event in last_event.items():
-        if event:
-            telescope_status[telescope_key].append({'telescope': str(telescope_key),
-                                                    'event_type': event['type'],
-                                                    'event_reason': event['reason'],
-                                                    'start': datetime.strptime(event['timestamp'],
-                                                                               ES_STRING_FORMATTER)
-                                                    .replace(tzinfo=timezone.utc),
-                                                    'end': end})
+        # If the event is close enough to the latest timestamp in the lump, it belongs in that lump.
+        if time_diff < dt:
+            return True
 
-    return telescope_status
+        # If the event is far in time from the lump, but has the same reason, that means it came from the same
+        # scheduling run as that timestamp and belongs in the lump.
+        if time_diff >= dt and event_source['reason'] in lump_data['reasons']:
+            return True
+
+        # If the event is an ENCLOSURE_INTERLOCK, and the lump includes a SEQUENCER_UNAVAILABLE, it is part of the
+        # lump. This is because the two states are redundant.
+        if event_source['type'] == 'ENCLOSURE_INTERLOCK' and 'SEQUENCER_UNAVAILABLE' in lump_data['types']:
+            return True
+
+        return False
+
+    def _categorize(self, lump):
+        # TODO: Categorize each lump in a useful way for network users.
+        event_type, event_reason = lump['types'][0], lump['reasons'][0]
+        for this_type, this_reason in zip(lump['types'], lump['reasons']):
+            # If the state in ENCLOSURE INTERLOCK, wait to instead categorize as SEQUENCER_UNAVAILABLE.
+            if this_type.upper() != 'ENCLOSURE_INTERLOCK':
+                event_type, event_reason = this_type, this_reason
+                break
+        return event_type, event_reason
+
+    def _lump_end(self, lump, next_event=None):
+        if not next_event or str(lump['telescope']) != str(self._telescope(next_event)):
+            return self.end
+        return self._es_to_datetime(next_event['timestamp'])
+
+    def _set_lump(self, event):
+        return {
+            'reasons': [event['_source']['reason']],
+            'types': [event['_source']['type']],
+            'start': self._es_to_datetime(event['_source']['timestamp']),
+            'telescope': self._telescope(event['_source']),
+            'latest_timestamp': self._es_to_datetime(event['_source']['timestamp'])
+        }
+
+    def _update_lump(self, lump, event):
+        if event['_source']['type'] not in lump['types'] or event['_source']['reason'] not in lump['reasons']:
+            lump['reasons'].append(event['_source']['reason'])
+            lump['types'].append(event['_source']['type'])
+        lump['latest_timestamp'] = self._es_to_datetime(event['_source']['timestamp'])
+        return lump
+
+    def get(self):
+        telescope_states = {}
+        current_lump = dict(reasons=None, types=None, start=None)
+
+        for event in self.event_data:
+            if self._telescope(event['_source']) not in self.available_telescopes:
+                continue
+
+            if current_lump['start'] is None:
+                current_lump = self._set_lump(event)
+                continue
+
+            if self._belongs_in_lump(event['_source'], current_lump):
+                current_lump = self._update_lump(current_lump, event)
+            else:
+                lump_end = self._lump_end(current_lump, event['_source'])
+                if lump_end < self.start:
+                    current_lump = self._set_lump(event)
+                    continue
+
+                telescope_states = self._update_states(telescope_states, current_lump, lump_end)
+                current_lump = self._set_lump(event)
+
+        if current_lump['start']:
+            lump_end = self._lump_end(current_lump)
+            telescope_states = self._update_states(telescope_states, current_lump, lump_end)
+
+        return telescope_states
+
+    def _update_states(self, states, lump, lump_end):
+        if lump['telescope'] not in states:
+            states[lump['telescope']] = []
+
+        event_type, event_reason = self._categorize(lump)
+        states[lump['telescope']].append(
+            {
+                'telescope': str(lump['telescope']),
+                'event_type': event_type,
+                'event_reason': event_reason,
+                'start': max(self.start, lump['start']),
+                'end': lump_end
+            }
+        )
+        return states
+
+    def _es_to_datetime(self, timestamp):
+        return datetime.strptime(timestamp, ES_STRING_FORMATTER).replace(tzinfo=timezone.utc)
+
+    def _telescope(self, event_source):
+        return TelescopeKey(
+            site=event_source['site'],
+            observatory=event_source['enclosure'],
+            telescope=event_source['telescope']
+        )
 
 
 def filter_telescope_states_by_intervals(telescope_states, sites_intervals, start, end):
@@ -170,7 +242,7 @@ def filter_telescope_states_by_intervals(telescope_states, sites_intervals, star
 
 
 def get_telescope_availability_per_day(start, end, telescopes=None, sites=None, instrument_types=None):
-    telescope_states = get_telescope_states(start, end, telescopes, sites, instrument_types)
+    telescope_states = TelescopeStates(start, end, telescopes, sites, instrument_types).get()
     # go through each telescopes list of states, grouping it up by observing night at the site
     rise_set_intervals = {}
     for telescope_key, events in telescope_states.items():

--- a/valhalla/userrequests/request_utils.py
+++ b/valhalla/userrequests/request_utils.py
@@ -3,7 +3,7 @@ from rise_set.angle import Angle
 from rise_set.astrometry import calculate_airmass_at_times
 
 from valhalla.common.configdb import configdb
-from valhalla.common.telescope_states import get_telescope_states, filter_telescope_states_by_intervals
+from valhalla.common.telescope_states import TelescopeStates, filter_telescope_states_by_intervals
 from valhalla.common.rise_set_utils import get_rise_set_target, get_rise_set_intervals
 
 MOLECULE_TYPE_DISPLAY = {
@@ -35,12 +35,12 @@ def get_telescope_states_for_request(request):
         return {}
 
     # Retrieve the telescope states for that set of sites
-    telescope_states = get_telescope_states(
+    telescope_states = TelescopeStates(
       start=request.min_window_time,
       end=request.max_window_time,
       sites=list(site_intervals.keys()),
       instrument_types=[instrument_type]
-    )
+    ).get()
     # Remove the empty intervals from the dictionary
     site_intervals = {site: intervals for site, intervals in site_intervals.items() if intervals}
 


### PR DESCRIPTION
The changes on this branch do the following:
- With no arguments to the telescope states endpoint, return the current state of each telescope.
- Return all states spanning the given window.
- When there is more than one state reported in ES for a telescope at a given time, only return one of those states in the endpoint.

I modified the test data that is returned by the mocked elasticsearch instance seeing as now the results must also be sorted by telescope whereas before they were only sorted by time.