### PR TITLE
fixed the molecule priority to be set in ascending order if it is not…

### DIFF
--- a/valhalla/userrequests/models.py
+++ b/valhalla/userrequests/models.py
@@ -356,7 +356,7 @@ class Molecule(models.Model):
     # Place-holder for future functionality, allowing arguments to be
     # passed along with a molecule
     args = models.TextField(default='', blank=True)
-    # TODO we don't know if this is necessary or if it is used
+    # Used by the pond for ordering the molecules
     priority = models.IntegerField(default=500)
 
     # Autoguider

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -241,6 +241,11 @@ class RequestSerializer(serializers.ModelSerializer):
         if not value:
             raise serializers.ValidationError(_('You must specify at least 1 molecule'))
 
+        # Set the relative priority of molecules in order if they don't have a priority already set
+        for i, molecule in enumerate(value):
+            if 'priority' not in molecule:
+                molecule['priority'] = i + 1
+
         # Make sure each molecule has the same instrument name
         if len(set(molecule['instrument_name'] for molecule in value)) > 1:
             raise serializers.ValidationError(_('Each Molecule must specify the same instrument name'))


### PR DESCRIPTION
… specified by user

This is a 'feature' of requestdb that we forgot to include, and the result is that users molecules are observed in random orders instead of the order that they submitted them in.