### PR TITLE
Feature/nres ui

### DIFF
--- a/static/js/components/molecule.vue
+++ b/static/js/components/molecule.vue
@@ -35,10 +35,10 @@
       </div>
       <div :class="show ? 'col-md-6' : 'col-md-12'">
         <form class="form-horizontal">
-          <customselect v-if="datatype === 'IMAGE'" v-model="molecule.filter" label="Filter" v-on:input="update"
+          <customselect v-if="molecule.type === 'EXPOSE'" v-model="molecule.filter" label="Filter" v-on:input="update"
                          :errors="errors.filter" :options="filterOptions" desc="The filter to be used with this instrument">
           </customselect>
-          <customselect v-if="datatype === 'SPECTRA'" v-model="molecule.spectra_slit" label="Slit Width" v-on:input="update"
+          <customselect v-if="molecule.type === 'SPECTRUM'" v-model="molecule.spectra_slit" label="Slit Width" v-on:input="update"
                          :errors="errors.spectra_slit" :options="filterOptions" desc="The width the of the slit to be used.">
           </customselect>
           <customfield v-model="molecule.exposure_count" label="Exposure Count" field="exposure_count" v-on:input="update"
@@ -150,8 +150,10 @@ export default {
   watch: {
     selectedinstrument: function(value){
       if(this.molecule.instrument_name != value){
+        if(value.includes('NRES')){
+          this.molecule.type = 'NRES_SPECTRUM'
+        }
         this.molecule.instrument_name = value;
-        this.molecule.filter = '';
         // wait for options to update, then set default
         var that = this;
         setTimeout(function(){

--- a/static/js/components/userrequest.vue
+++ b/static/js/components/userrequest.vue
@@ -117,10 +117,7 @@ export default {
       that.proposals = data.proposals;
       that.simple_interface = data.profile.simple_interface;
       for(var ai in data.available_instrument_types){
-        // TODO remove this hardocded exclusion of NRES
-        if(!data.available_instrument_types[ai].includes('NRES')){
-          allowed_instruments[data.available_instrument_types[ai]] = {};
-        }
+        allowed_instruments[data.available_instrument_types[ai]] = {};
       }
     }).done(function(){
       $.getJSON('/api/instruments/', function(data){


### PR DESCRIPTION
We need to enable NRES on the UI for it's release. There's some weirdness with NRES that breaks our model a bit - it has a molecule type of 'NRES_SPECTRUM' rather than just 'SPECTRUM'. Previously the molecule type was only set when the 'Observation Type' field was changed, but now that isn't enough information on it's own, so I change the molecule type to NRES_SPECTRUM if the Instrument is changed to NRES. Let me know if you have a better idea of handling NRES in here.

There may be more fields that need to be added/shown/hidden based on the instrument being NRES - I just need a first draft to put on the dev cluster for Rob/Nikolaus to play with before they tell me.