### PR TITLE
updated minimum visjs timeline size to fit tooltips. Set tooltips to …

### DIFF
--- a/static/js/components/blockhistory.vue
+++ b/static/js/components/blockhistory.vue
@@ -43,6 +43,7 @@ export default {
     var options = {
       groupOrder: 'content',
       maxHeight: '450px',
+      minHeight: '120px',
       align: 'right',
       dataAttributes: ['toggle', 'html'],
       selectable: false,
@@ -50,6 +51,9 @@ export default {
       zoomKey: 'ctrlKey',
       moment: function (date) {
         return vis.moment(date).utc();
+      },
+      tooltip: {
+        overflowMethod: 'cap',
       }
     };
 
@@ -174,7 +178,7 @@ export default {
       plot.on('changed', function () {
         //HAX
         $(that.$el).find('.vis-group').mouseover(function () {
-          $(that.$el).find('.vis-item').tooltip({container: 'body'});
+          $(that.$el).find('.vis-item').tooltip({container: 'body', 'placement': 'top'});
         });
       });
       return plot;

--- a/static/js/components/telescope_states.vue
+++ b/static/js/components/telescope_states.vue
@@ -33,12 +33,16 @@ export default {
       groupOrder: 'id',
       stack: false,
       maxHeight: '450px',
+      minHeight: '120px',
       align: 'left',
       dataAttributes: ['toggle', 'html'],
       selectable: false,
       zoomKey: 'ctrlKey',
       moment: function (date) {
         return vis.moment(date).utc();
+      },
+      tooltip: {
+        overflowMethod: 'cap',
       }
     };
 


### PR DESCRIPTION
…cap mode which keeps them visible as well

Couldn't fix tooltips on the airmass plot (graph2d) because those are through bootstrap 3, and bootstrap 3 will not fix (switch to bootstrap 4 if you want support)