### PR TITLE
fixed bug in telescope class not showing up if you only have spectral…

### DIFF
--- a/static/js/components/request.vue
+++ b/static/js/components/request.vue
@@ -96,7 +96,7 @@ export default {
   },
   watch: {
     data_type: function(){
-      if(Object.keys(this.available_instruments).length && this.available_instruments[this.instrument_name].type != this.data_type){
+      if(Object.keys(this.available_instruments).length && (!this.instrument_name || this.available_instruments[this.instrument_name].type != this.data_type)){
         this.instrument_name = this.firstAvailableInstrument;
         this.update();
       }


### PR DESCRIPTION
… time. This is because instrument_name is not set in this case, which causes this comparison to fail when it should be succeeding (because it populates instrument class)