### PR TITLE
ag_mode cannot be OFF for nres observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.9.5
+2018-01-19
+
+* Prevent NRES observations specifying ag_mode OFF
+
 ## 1.9.4
 2018-01-05
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ time_intervals<2.0
 WeasyPrint>=0.42<0.43
 PyPDF2>=1.26,<1.27
 elasticsearch>=6.0,<6.1
-numpy>=1.13,<1.14
+numpy>=1.14, <1.15
 celery[redis]>=4.0.<4.1
 django-redis-cache>=1.7,<1.8
 psycopg2>=2.7,<2.8

--- a/static/js/components/molecule.vue
+++ b/static/js/components/molecule.vue
@@ -55,7 +55,7 @@
           <customfield v-model="molecule.defocus" v-if="datatype != 'SPECTRA' && !simple_interface" label="Defocus" field="defocus" v-on:input="update"
                        :errors="errors.defocus" desc="Observations may be defocused to prevent the CCD from saturating on bright targets. This term describes the offset (in mm) of the secondary mirror from its default (focused) position. The limits are ± 3mm.">
           </customfield>
-          <customselect v-model="molecule.ag_mode" label="Guiding" field="ag_mode" v-on:input="update" v-if="!simple_interface"
+          <customselect v-model="molecule.ag_mode" label="Guiding" field="ag_mode" v-on:input="update" v-if="!simple_interface && showAgMode"
                         :errors="errors.ag_mode" desc="Guiding keeps the field stable during long exposures. If OPTIONAL is selected, then guiding is attempted, but the observations will be carried out even if guiding fails. If ON is selected, then if guiding fails, the observations will be aborted."
                         :options="[{value: 'OPTIONAL', text: 'Optional'},
                                    {value: 'OFF', text: 'Off'},
@@ -97,6 +97,7 @@ export default {
   data: function(){
     return {
       show: true,
+      showAgMode: true,
       acquire_params: {
         acquire_mode: 'WCS',
         acquire_radius_arcsec: null
@@ -150,6 +151,7 @@ export default {
     setupImager: function(){
       this.molecule.type = 'EXPOSE';
       this.molecule.spectra_slit = undefined;
+      this.showAgMode = true;
       this.acquire_params.acquire_mode = this.molecule.acquire_mode;
       this.molecule.acquire_mode = undefined;
       this.molecule.acquire_radius_arcsec = undefined;
@@ -161,12 +163,14 @@ export default {
     setupNRES: function(){
       this.molecule.type = 'NRES_SPECTRUM';
       this.setupSpectrograph();
+      this.showAgMode = false;
       this.molecule.acquire_mode = 'BRIGHTEST';
       this.molecule.acquire_radius_arcsec = this.acquire_params.acquire_radius_arcsec;
     },
     setupFLOYDS: function(){
        this.molecule.type = 'SPECTRUM';
        this.setupSpectrograph();
+       this.showAgMode = true;
        this.molecule.acquire_mode = this.acquire_params.acquire_mode;
        if (this.molecule.acquire_mode === 'BRIGHTEST'){
          this.molecule.acquire_radius_arcsec = this.acquire_params.acquire_radius_arcsec;

--- a/valhalla/common/configdb.py
+++ b/valhalla/common/configdb.py
@@ -236,5 +236,9 @@ class ConfigDB(object):
         return instrument_type.upper() in ['2M0-FLOYDS-SCICAM', '0M8-NRES-SCICAM', '1M0-NRES-SCICAM',
                                            '1M0-NRES-COMMISSIONING']
 
+    @staticmethod
+    def is_nres(instrument_type):
+        return 'NRES' in instrument_type.upper()
+
 
 configdb = ConfigDB()

--- a/valhalla/common/test_data/configdb.json
+++ b/valhalla/common/test_data/configdb.json
@@ -135,6 +135,38 @@
                 },
                 {
                   "state": "SCHEDULABLE",
+                  "code": "nresXX",
+                  "science_camera": {
+                    "camera_type": {
+                      "code": "1M0-NRES-SCICAM",
+                      "name": "1M0-NRES-SCICAM",
+                      "default_mode": {
+                        "binning": 2,
+                        "readout": 90.5
+                      },
+                      "config_change_time": 0,
+                      "acquire_processing_time": 90,
+                      "acquire_exposure_time": 10,
+                      "front_padding": 270,
+                      "filter_change_time": 2,
+                      "fixed_overhead_per_exposure": 1,
+                      "mode_set": [
+                        {
+                          "binning": 1,
+                          "readout": 35.0
+                        },
+                        {
+                          "binning": 2,
+                          "readout": 90.5
+                        }
+                      ]
+                    },
+                    "filters": "air"
+                  },
+                  "__str__": "tst.domb.1m0a.nresXX-nresXX"
+                },
+                {
+                  "state": "SCHEDULABLE",
                   "code": "xx04",
                   "science_camera": {
                     "camera_type": {

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -83,6 +83,11 @@ class MoleculeSerializer(serializers.ModelSerializer):
             if data['acquire_mode'] == 'BRIGHTEST' and not data.get('acquire_radius_arcsec'):
                 raise serializers.ValidationError({'acquire_radius_arcsec': 'Acquire radius must be positive.'})
 
+        # NRES must not have ag_mode 'OFF'
+        if configdb.is_nres(data['instrument_name']):
+            if data['ag_mode'] == 'OFF':
+                raise serializers.ValidationError({'ag_mode': _('Autoguiding must not be off for NRES observations.')})
+
         types_that_require_filter = ['expose', 'auto_focus', 'zero_pointing', 'standard', 'sky_flat']
         types_that_require_slit = ['spectrum', 'arc', 'lamp_flat']
 

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -1085,6 +1085,16 @@ class TestMoleculeApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         self.assertEqual(molecule['ag_mode'], 'ON')
         self.assertEqual(molecule['spectra_slit'], 'slit_6.0as')
 
+    def test_ag_mode_off_not_allowed_for_nres(self):
+        bad_data = self.generic_payload.copy()
+        bad_data['requests'][0]['molecules'][0]['instrument_name'] = '1M0-NRES-SCICAM'
+        bad_data['requests'][0]['molecules'][0]['type'] = 'NRES_SPECTRUM'
+        bad_data['requests'][0]['molecules'][0]['ag_mode'] = 'OFF'
+
+        response = self.client.post(reverse('api:user_requests-list'), data=bad_data)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Autoguiding must not be off', str(response.content))
+
     def test_invalid_filter_for_instrument(self):
         bad_data = self.generic_payload.copy()
         bad_data['requests'][0]['molecules'][0]['filter'] = 'magic'


### PR DESCRIPTION
Daniel decided ag_mode off makes no sense on nres observations, and it stops them from being able to be run at sites so we need to block it. Some guy submitted a bunch of observations with it and I manually changed, but this pull request is to automatically block that in the future