### PR TITLE
changed spectra guiding on to only be enforced for nres_spectrum and …

### DIFF
--- a/static/js/components/request.vue
+++ b/static/js/components/request.vue
@@ -152,8 +152,10 @@ export default {
         calibs[x].exposure_time = 60;
       }
       calibs[0].type = 'LAMP_FLAT'; calibs[1].type = 'ARC';
+      calibs[0].ag_mode = 'OPTIONAL'; calibs[1].ag_mode = 'OPTIONAL';
       request.molecules.unshift(calibs[0], calibs[1]);
       calibs[2].type = 'ARC'; calibs[3].type = 'LAMP_FLAT';
+      calibs[2].ag_mode = 'OPTIONAL'; calibs[3].ag_mode = 'OPTIONAL';
       request.molecules.push(calibs[2], calibs[3]);
       this.update();
     },

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -83,13 +83,14 @@ class MoleculeSerializer(serializers.ModelSerializer):
             if data['acquire_mode'] == 'BRIGHTEST' and not data.get('acquire_radius_arcsec'):
                 raise serializers.ValidationError({'acquire_radius_arcsec': 'Acquire radius must be positive.'})
 
-        # Spectrographs must have ag_mode 'ON'
-        if configdb.is_spectrograph(data['instrument_name']):
-            if data['ag_mode'] is not 'ON':
-                raise serializers.ValidationError({'ag_mode': _('Autoguiding must be on for spectrograph observations.')})
-
         types_that_require_filter = ['expose', 'auto_focus', 'zero_pointing', 'standard', 'sky_flat']
         types_that_require_slit = ['spectrum', 'arc', 'lamp_flat']
+        types_that_require_ag_mode_on = ['spectrum', 'nres_spectrum']
+
+        # Spectrum and NRES_SPECTRUM obs must have ag_mode 'ON'
+        if data['type'].lower() in types_that_require_ag_mode_on:
+            if data['ag_mode'] is not 'ON':
+                raise serializers.ValidationError({'ag_mode': _('Autoguiding must be on for {} observations.'.format(data['type']))})
 
         # check that the filter is available in the instrument type specified
         available_filters = configdb.get_filters(data['instrument_name'])

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -85,7 +85,7 @@ class MoleculeSerializer(serializers.ModelSerializer):
 
         types_that_require_filter = ['expose', 'auto_focus', 'zero_pointing', 'standard', 'sky_flat']
         types_that_require_slit = ['spectrum', 'arc', 'lamp_flat']
-        types_that_require_ag_mode_on = ['spectrum', 'nres_spectrum']
+        types_that_require_ag_mode_on = ['spectrum', 'nres_spectrum', 'nres_test', 'nres_expose']
 
         # Spectrum and NRES_SPECTRUM obs must have ag_mode 'ON'
         if data['type'].lower() in types_that_require_ag_mode_on:

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -1144,10 +1144,12 @@ class TestMoleculeApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 201)
 
         good_data['requests'][0]['molecules'][0]['type'] = 'NRES_EXPOSE'
+        good_data['requests'][0]['molecules'][0]['ag_mode'] = 'ON'
         response = self.client.post(reverse('api:user_requests-list'), data=good_data)
         self.assertEqual(response.status_code, 201)
 
         good_data['requests'][0]['molecules'][0]['type'] = 'NRES_TEST'
+        good_data['requests'][0]['molecules'][0]['ag_mode'] = 'ON'
         response = self.client.post(reverse('api:user_requests-list'), data=good_data)
         self.assertEqual(response.status_code, 201)
 


### PR DESCRIPTION
…spectrum molecule types. Gives lamp_flats and arcs in the compose page optional ag_mode.

Don't actually have to change any compose page UI stuff - just enforce that spectra calibration molecules have 'optional' and spectrum/nres_spectrum have 'on'