### PR TITLE
set the get_filters call to only get filters for instruments that are…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.2
+2018-02-28
+
+* only show filters for schedulable instruments
+
 ## 1.10.1
 2018-02-28
 

--- a/valhalla/common/configdb.py
+++ b/valhalla/common/configdb.py
@@ -140,7 +140,7 @@ class ConfigDB(object):
         :return: returns the available set of filters for an instrument_type
         '''
         available_filters = set()
-        for instrument in self.get_instruments():
+        for instrument in self.get_instruments(only_schedulable=True):
             if instrument_type.upper() == instrument['science_camera']['camera_type']['code'].upper():
                 for camera_filter in instrument['science_camera']['filters'].split(','):
                     available_filters.add(camera_filter.lower())


### PR DESCRIPTION
… schedulable

For https://issues.lco.global/issues/10166

Do you see any potential issues with this? The only two places get_filters is used is the /api/instruments/ filters list per instrument - which is used in the compose page filters field, and the molecule serializer.