### PR TITLE
Use BCC instead of TO for proposal notifications

### DIFF
--- a/valhalla/celery.py
+++ b/valhalla/celery.py
@@ -21,3 +21,8 @@ app.autodiscover_tasks()
 @app.task()
 def send_mail(*args, **kwargs):
     django_send_mail(*args, **kwargs)
+
+
+@app.task()
+def send_emailmessage(email_message):
+    email_message.send()

--- a/valhalla/proposals/notifications.py
+++ b/valhalla/proposals/notifications.py
@@ -1,6 +1,7 @@
 from django.template.loader import render_to_string
+from django.core.mail import EmailMessage
 
-from valhalla.celery import send_mail
+from valhalla.celery import send_emailmessage
 
 
 def users_to_notify(userrequest):
@@ -19,9 +20,11 @@ def userrequest_notifications(userrequest):
             'proposals/userrequestcomplete.txt',
             {'userrequest': userrequest}
         )
-        send_mail.delay(
-            'Request {} has completed'.format(userrequest.group_id),
-            message,
-            'portal@lco.global',
-            [u.email for u in users_to_notify(userrequest)]
+        email_message = EmailMessage(
+            subject='Request {} has completed'.format(userrequest.group_id),
+            body=message,
+            from_email='portal@lco.global',
+            to=[],
+            bcc=[u.email for u in users_to_notify(userrequest)]
         )
+        send_emailmessage.delay(email_message)

--- a/valhalla/proposals/tests.py
+++ b/valhalla/proposals/tests.py
@@ -86,7 +86,7 @@ class TestProposalNotifications(TestCase):
         self.userrequest.save()
         self.assertIn(self.userrequest.group_id, str(mail.outbox[0].message()))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].to, [self.user.email])
+        self.assertEqual(mail.outbox[0].bcc, [self.user.email])
 
     def test_single_proposal_notification(self):
         mixer.blend(Profile, user=self.user, notifications_enabled=False)
@@ -95,7 +95,7 @@ class TestProposalNotifications(TestCase):
         self.userrequest.save()
         self.assertIn(self.userrequest.group_id, str(mail.outbox[0].message()))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].to, [self.user.email])
+        self.assertEqual(mail.outbox[0].bcc, [self.user.email])
 
     def test_user_loves_notifications(self):
         mixer.blend(Profile, user=self.user, notifications_enabled=True)
@@ -104,7 +104,7 @@ class TestProposalNotifications(TestCase):
         self.userrequest.save()
         self.assertIn(self.userrequest.group_id, str(mail.outbox[0].message()))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].to, [self.user.email])
+        self.assertEqual(mail.outbox[0].bcc, [self.user.email])
 
     def test_notifications_only_authored(self):
         mixer.blend(Profile, user=self.user, notifications_enabled=True, notifications_on_authored_only=True)
@@ -113,7 +113,7 @@ class TestProposalNotifications(TestCase):
         self.userrequest.save()
         self.assertIn(self.userrequest.group_id, str(mail.outbox[0].message()))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].to, [self.user.email])
+        self.assertEqual(mail.outbox[0].bcc, [self.user.email])
 
     def test_no_notifications_only_authored(self):
         mixer.blend(Profile, user=self.user, notifications_enabled=True, notifications_on_authored_only=True)


### PR DESCRIPTION
This commit changes how proposal notifications are sent. Previously,
all recipients were listed under the TO field, which was causing
some emails to be marked as spam. They should be sent as BCC, so
that recipients can't see eachother's email addresses.