### PR TITLE
available_instruments depends on a call to the api and rarely populat…

### DIFF
--- a/static/js/components/request.vue
+++ b/static/js/components/request.vue
@@ -130,8 +130,9 @@ export default {
     instrumentToDataType: function(value){
       if (value.includes('NRES') || value.includes('FLOYDS')) {
         return 'SPECTRA';
+      } else {
+        return 'IMAGE';
       }
-      return 'IMAGE';
     },
     moleculeFillWindow: function(molecule_id){
       console.log('moleculefillwindow');

--- a/static/js/components/request.vue
+++ b/static/js/components/request.vue
@@ -128,8 +128,8 @@ export default {
       }
     }, 300),
     instrumentToDataType: function(value){
-      if(!_.isEmpty(this.available_instruments) && value) {
-        return this.available_instruments[value].type;
+      if (value.includes('NRES') || value.includes('FLOYDS')) {
+        return 'SPECTRA';
       }
       return 'IMAGE';
     },


### PR DESCRIPTION
…es before the call to instrumentToDataType, making data_type almost always be IMAGE. Determine data_type from instrument_name instead.