### PR TITLE
change the max_allowable_ipp time from rounding to flooring.

### DIFF
--- a/valhalla/userrequests/duration_utils.py
+++ b/valhalla/userrequests/duration_utils.py
@@ -1,6 +1,6 @@
 import itertools
 from django.utils.translation import ugettext as _
-from math import ceil
+from math import ceil, floor
 import logging
 
 from valhalla.proposals.models import TimeAllocationKey, Proposal, Semester
@@ -81,7 +81,7 @@ def get_max_ipp_for_userrequest(userrequest_dict):
         duration_hours = duration / 3600.0
         ipp_available = time_allocation.ipp_time_available
         max_ipp_allowable = min((ipp_available / duration_hours) + 1.0, MAX_IPP_LIMIT)
-        truncated_max_ipp_allowable = ((max_ipp_allowable * 1000.0) // 1) / 1000.0
+        truncated_max_ipp_allowable = floor(max_ipp_allowable * 1000.0) / 1000.0
         if tak.semester not in ipp_dict:
             ipp_dict[tak.semester] = {}
         if tak.telescope_class not in ipp_dict[tak.semester]:

--- a/valhalla/userrequests/duration_utils.py
+++ b/valhalla/userrequests/duration_utils.py
@@ -81,7 +81,7 @@ def get_max_ipp_for_userrequest(userrequest_dict):
         duration_hours = duration / 3600.0
         ipp_available = time_allocation.ipp_time_available
         max_ipp_allowable = min((ipp_available / duration_hours) + 1.0, MAX_IPP_LIMIT)
-        max_ipp_allowable = float("{:.3f}".format(max_ipp_allowable))
+        truncated_max_ipp_allowable = ((max_ipp_allowable * 1000.0) // 1) / 1000.0
         if tak.semester not in ipp_dict:
             ipp_dict[tak.semester] = {}
         if tak.telescope_class not in ipp_dict[tak.semester]:
@@ -90,7 +90,7 @@ def get_max_ipp_for_userrequest(userrequest_dict):
             'ipp_time_available': ipp_available,
             'ipp_limit': time_allocation.ipp_limit,
             'request_duration': duration_hours,
-            'max_allowable_ipp_value': max_ipp_allowable,
+            'max_allowable_ipp_value': truncated_max_ipp_allowable,
             'min_allowable_ipp_value': MIN_IPP_LIMIT
         }
     return ipp_dict

--- a/valhalla/userrequests/state_changes.py
+++ b/valhalla/userrequests/state_changes.py
@@ -91,13 +91,14 @@ def validate_ipp(ur_dict, total_duration_dict):
         duration_hours = duration / 3600.0
         if time_allocations_dict[tak] < (duration_hours * ipp_value):
             max_ipp_allowable = (time_allocations_dict[tak] / duration_hours) + 1.0
+            truncated_max_ipp_allowable = ((max_ipp_allowable * 1000.0) // 1) / 1000.0
             msg = _(("{}-{}'{}' ipp_value of {} requires more ipp_time then is available. "
-                     "Please lower your ipp_value to <= {:.3f} and submit again.")).format(
+                     "Please lower your ipp_value to <= {} and submit again.")).format(
                 tak.telescope_class,
                 tak.instrument_name,
                 ur_dict['observation_type'],
                 (ipp_value + 1),
-                max_ipp_allowable
+                truncated_max_ipp_allowable
             )
             raise TimeAllocationError(msg)
         time_allocations_dict[tak] -= (duration_hours * ipp_value)

--- a/valhalla/userrequests/state_changes.py
+++ b/valhalla/userrequests/state_changes.py
@@ -9,7 +9,7 @@ from valhalla.userrequests.models import UserRequest, Request
 import itertools
 import logging
 import dateutil.parser
-from math import isclose
+from math import isclose, floor
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ def validate_ipp(ur_dict, total_duration_dict):
         duration_hours = duration / 3600.0
         if time_allocations_dict[tak] < (duration_hours * ipp_value):
             max_ipp_allowable = (time_allocations_dict[tak] / duration_hours) + 1.0
-            truncated_max_ipp_allowable = ((max_ipp_allowable * 1000.0) // 1) / 1000.0
+            truncated_max_ipp_allowable = floor(max_ipp_allowable * 1000.0) / 1000.0
             msg = _(("{}-{}'{}' ipp_value of {} requires more ipp_time then is available. "
                      "Please lower your ipp_value to <= {} and submit again.")).format(
                 tak.telescope_class,

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -2198,6 +2198,18 @@ class TestMaxIppUserrequestApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         # max ipp allowable is close to 1.0 ipp_available / 1.5 ~duration + 1.
         self.assertEqual(1.649, ipp_dict[self.semester.id]['1m0']['1M0-SCICAM-SBIG']['max_allowable_ipp_value'])
 
+    def test_get_max_ipp_rounds_down(self):
+        good_data = self.generic_payload.copy()
+        good_data['requests'][0]['molecules'][0]['exposure_time'] = 90.0 * 60.0  # 90 minute exposure (1.0 ipp available)
+        self.time_allocation_1m0_sbig.ipp_time_available = 1.33
+        self.time_allocation_1m0_sbig.save()
+        response = self.client.post(reverse('api:user_requests-max-allowable-ipp'), good_data)
+        self.assertEqual(response.status_code, 200)
+        ipp_dict = response.json()
+        self.assertIn(self.semester.id, ipp_dict)
+        # max ipp allowable is close to 1.0 ipp_available / 1.5 ~duration + 1.
+        self.assertEqual(1.863, ipp_dict[self.semester.id]['1m0']['1M0-SCICAM-SBIG']['max_allowable_ipp_value'])
+
     def test_get_max_ipp_no_ipp_available(self):
         good_data = self.generic_payload.copy()
         good_data['ipp_value'] = 2.0


### PR DESCRIPTION
To fix issue https://issues.lco.global/issues/10160#change-74292. 

It is surprisingly difficult to just truncate a float, because of float precision issues. This way should be either accurate, or underestimating what the max_allowable_ipp is by 0.001. I could not find a way to always make it 100% accurate because there are certain 3 digit numbers that cannot be represented by floats. Either way this should be fine for users.