### PR TITLE
Check that the autoguider is either an empty string or default ag beh…

### DIFF
--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -265,6 +265,11 @@ class RequestSerializer(serializers.ModelSerializer):
         if len(set(molecule['instrument_name'] for molecule in value)) > 1:
             raise serializers.ValidationError(_('Each Molecule must specify the same instrument name'))
 
+        # Validate autoguiders - empty string for default behavior, or match with instrument name for self guiding
+        for molecule in value:
+            if str(molecule['ag_name']).lower() not in ['', str(molecule['instrument_name']).lower()]:
+                raise serializers.ValidationError(_('Molecule `ag_name` must be blank or same as `instrument_name`'))
+
         if sum([mol.get('fill_window', False) for mol in value]) > 1:
             raise serializers.ValidationError(_('Only one molecule can have `fill_window` set'))
 

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -267,7 +267,8 @@ class RequestSerializer(serializers.ModelSerializer):
 
         # Validate autoguiders - empty string for default behavior, or match with instrument name for self guiding
         for molecule in value:
-            if str(molecule['ag_name']).lower() not in ['', str(molecule['instrument_name']).lower()]:
+            allowed_autoguiders = ['', str(molecule['instrument_name']).lower()]
+            if 'ag_name' in molecule and str(molecule['ag_name']).lower() not in allowed_autoguiders:
                 raise serializers.ValidationError(_('Molecule `ag_name` must be blank or same as `instrument_name`'))
 
         if sum([mol.get('fill_window', False) for mol in value]) > 1:

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -46,6 +46,7 @@ generic_payload = {
             'exposure_count': 1,
             'bin_x': 1,
             'bin_y': 1,
+            'ag_name': '',
         }],
         'windows': [{
             'start': '2016-09-29T21:12:18Z',
@@ -172,6 +173,21 @@ class TestUserPostRequestApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         bad_data['requests'][0]['molecules'] = []
         response = self.client.post(reverse('api:user_requests-list'), data=bad_data)
         self.assertEqual(response.status_code, 400)
+
+    def test_post_userrequest_validate_autoguider(self):
+        data = self.generic_payload.copy()
+        # Verify invalid autoguider string fails validation
+        data['requests'][0]['molecules'][0]['ag_name'] = 'invalidAutoguider'
+        response = self.client.post(reverse('api:user_requests-list'), data=data)
+        self.assertEqual(response.status_code, 400)
+        # Verify empty string passes validation and creates UR
+        data['requests'][0]['molecules'][0]['ag_name'] = ''
+        response = self.client.post(reverse('api:user_requests-list'), data=data)
+        self.assertEqual(response.status_code, 201)
+        # Verify instrument_name as ag_name passes validation and creates UR
+        data['requests'][0]['molecules'][0]['ag_name'] = data['requests'][0]['molecules'][0]['instrument_name']
+        response = self.client.post(reverse('api:user_requests-list'), data=data)
+        self.assertEqual(response.status_code, 201)
 
     def test_post_userrequest_no_requests(self):
         bad_data = self.generic_payload.copy()
@@ -1630,6 +1646,7 @@ class TestAirmassApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
                 'exposure_count': 1,
                 'bin_x': 1,
                 'bin_y': 1,
+                'ag_name': ''
             }],
             'windows': [{
                 'start': '2016-09-29T21:12:18Z',


### PR DESCRIPTION
…avior, or the same as the instrument for self guiding.

Intentionally allows different molecules to have different ag_names set, as long as they're valid. 

Also, what do you think- should the validation error message say "...must be blank..." as it does now, or would saying "...must be empty string..." be more user friendly?