### PR TITLE
Add ability to delete proposal invitations

### DIFF
--- a/valhalla/proposals/templates/proposals/membership_confirm_delete.html
+++ b/valhalla/proposals/templates/proposals/membership_confirm_delete.html
@@ -2,6 +2,6 @@
 {% block content %}
 <form action="" method="post">{% csrf_token %}
     <p>Are you sure you want to remove {{ object.user.email }} from this proposal?</p>
-    <input type="submit" value="Confirm" />
+    <input type="submit" value="Confirm" class="btn btn-danger"/>
 </form>
 {% endblock %}

--- a/valhalla/proposals/templates/proposals/proposal_detail.html
+++ b/valhalla/proposals/templates/proposals/proposal_detail.html
@@ -174,6 +174,7 @@
             {% if not invite.used %}
             <dd><a href="mailto:{{ invite.email }}">{{ invite.email }}</a></dd>
             <dd>Invited: {{ invite.sent }}</dd>
+            <dd><a href="{% url 'proposals:proposalinvite-delete' invite.id %}">Delete</a></dd>
             {% endif %}
             {% empty %}
             <p>No pending invitations.</p>

--- a/valhalla/proposals/templates/proposals/proposalinvite_confirm_delete.html
+++ b/valhalla/proposals/templates/proposals/proposalinvite_confirm_delete.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<form action="" method="post">{% csrf_token %}
+    <p>Are you sure you want to delete the invitation for {{ object.email }} for this proposal?</p>
+    <input type="submit" value="Confirm" class="btn btn-danger" />
+</form>
+{% endblock %}

--- a/valhalla/proposals/urls.py
+++ b/valhalla/proposals/urls.py
@@ -3,7 +3,7 @@ from django.views.decorators.http import require_POST
 
 from valhalla.proposals.views import ProposalDetailView, ProposalListView, InviteCreateView
 from valhalla.proposals.views import MembershipDeleteView, SemesterAdminView, MembershipLimitView
-from valhalla.proposals.views import GlobalMembershipLimitView, SemesterDetailView
+from valhalla.proposals.views import GlobalMembershipLimitView, SemesterDetailView, ProposalInviteDeleteView
 
 app_name = 'proposals'
 urlpatterns = [
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^membership/(?P<pk>.+)/limit/$', MembershipLimitView.as_view(), name='membership-limit'),
     url(r'^semester/(?P<pk>.+)/$', SemesterDetailView.as_view(), name='semester-detail'),
     url(r'^semesteradmin/(?P<pk>.+)/$', SemesterAdminView.as_view(), name='semester-admin'),
+    url(r'^invitation/(?P<pk>.+)/delete/$', ProposalInviteDeleteView.as_view(), name='proposalinvite-delete'),
     url(r'^$', ProposalListView.as_view(), name='list'),
     url(r'^(?P<pk>.+)/invite/$', require_POST(InviteCreateView.as_view()), name='invite'),
     url(r'^(?P<pk>.+)/globallimit/$', require_POST(GlobalMembershipLimitView.as_view()), name='membership-global'),

--- a/valhalla/proposals/views.py
+++ b/valhalla/proposals/views.py
@@ -15,7 +15,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 
 from valhalla.sciapplications.models import Call
 from valhalla.proposals.forms import ProposalNotificationForm
-from valhalla.proposals.models import Proposal, Membership, ProposalNotification, Semester
+from valhalla.proposals.models import Proposal, Membership, ProposalNotification, Semester, ProposalInvite
 from valhalla.proposals.filters import ProposalFilter
 
 
@@ -109,6 +109,17 @@ class InviteCreateView(LoginRequiredMixin, View):
             proposal.add_users(emails, Membership.CI)
             messages.success(request, _('Co Investigator(s) invited'))
         return HttpResponseRedirect(reverse('proposals:detail', kwargs={'pk': proposal.id}))
+
+
+class ProposalInviteDeleteView(LoginRequiredMixin, DeleteView):
+    model = ProposalInvite
+
+    def get_success_url(self):
+        return reverse_lazy('proposals:detail', kwargs={'pk': self.get_object().proposal.id})
+
+    def get_queryset(self):
+        proposals = self.request.user.proposal_set.filter(membership__role=Membership.PI)
+        return ProposalInvite.objects.filter(proposal__in=proposals)
 
 
 class MembershipDeleteView(LoginRequiredMixin, DeleteView):


### PR DESCRIPTION
Some programs have the need to delete proposal invitations on a regular
basis. This pull request adds a view that allows the PI of a proposal to
delete invitations so that the invited user will no longer be added to
the proposal when signing up for an account (if they ever sign up for an
account).

Delivers https://www.pivotaltracker.com/story/show/161568643