### PR TITLE
Feature/scicollab admins as pis

### DIFF
--- a/valhalla/sciapplications/forms.py
+++ b/valhalla/sciapplications/forms.py
@@ -47,23 +47,11 @@ class BaseProposalAppForm(ModelForm):
 
     def clean(self):
         super().clean()
-        if self.cleaned_data.get('pi'):
-            self.Meta.required_fields.update(['pi_first_name', 'pi_last_name', 'pi_institution'])
-        else:
-            for field in ['pi_first_name', 'pi_last_name', 'pi_institution']:
-                if field in self.Meta.required_fields:
-                    self.Meta.required_fields.remove(field)
         for field in self.Meta.required_fields:
             if not self.cleaned_data.get(field) and self.cleaned_data.get('status') == 'SUBMITTED':
                 self.add_error(field, _('{}: This field is required'.format(self.fields[field].label)))
         if self.errors:
             self.add_error(None, _('There was an error with your submission.'))
-
-    def clean_pi(self):
-        email = self.cleaned_data.get('pi')
-        if email and email.strip() == self.instance.submitter.email:
-            raise forms.ValidationError(_('Leave these fields blank if you are the PI'))
-        return email
 
     def clean_pdf(self):
         pdf = self.cleaned_data.get('pdf')
@@ -99,9 +87,7 @@ class ScienceProposalAppForm(BaseProposalAppForm):
             'call', 'status', 'title', 'pi', 'pi_first_name', 'pi_last_name', 'pi_institution',
             'abstract', 'pdf'
         )
-        required_fields = set(fields) - set((
-            'pi', 'pi_first_name', 'pi_last_name', 'pi_institution'
-        ))
+        required_fields = set(fields)
 
 
 class DDTProposalAppForm(BaseProposalAppForm):
@@ -113,9 +99,7 @@ class DDTProposalAppForm(BaseProposalAppForm):
             'call', 'status', 'title', 'pi', 'pi_first_name', 'pi_last_name', 'pi_institution',
             'pdf',
         )
-        required_fields = set(fields) - set((
-            'pi', 'pi_first_name', 'pi_last_name', 'pi_institution'
-        ))
+        required_fields = set(fields)
 
 
 class KeyProjectAppForm(BaseProposalAppForm):
@@ -127,9 +111,7 @@ class KeyProjectAppForm(BaseProposalAppForm):
             'call', 'status', 'title', 'pi', 'pi_first_name', 'pi_last_name', 'pi_institution',
             'abstract', 'pdf'
         )
-        required_fields = set(fields) - set((
-            'pi', 'pi_first_name', 'pi_last_name', 'pi_institution',
-        ))
+        required_fields = set(fields)
 
 
 class SciCollabAppForm(BaseProposalAppForm):

--- a/valhalla/sciapplications/models.py
+++ b/valhalla/sciapplications/models.py
@@ -170,7 +170,8 @@ class ScienceApplication(models.Model):
                 proposal=proposal
             )
 
-        # Send invitations if necessary
+        # Send invitations if necessary. The check is done because the pi field may not be set at this point,
+        # making the submitter the PI on the proposal by default.
         if self.pi:
             proposal.add_users([self.pi], Membership.PI)
         else:

--- a/valhalla/sciapplications/templates/sciapplications/create.html
+++ b/valhalla/sciapplications/templates/sciapplications/create.html
@@ -44,27 +44,15 @@
 
             {% if form.pi %}
                 {% bootstrap_label 'Principal Investigator' label_for=id_pi %}
-                {% if call.proposal_type != 'COLAB' %}
                 <div class="help-block">
-                    Please ensure the following information is correct and up to date. You can update these
-                    details on you <a href="{% url 'profile' %}">profile</a> page.
+                    <strong>If you are the principal investigator on this proposal, please ensure your information
+                        is correct and up to date before proceeding. You can view and update your details on your
+                        <a href="{% url 'profile' %}">profile</a> page.
+                    </strong>
                 </div>
-                 <table id="mepi" class="table">
-                  <thead><tr><th>Email</th><th>First Name</th><th>Last Name</th><th>Institution</th></tr></thead>
-                  <tr>
-                    <td>{{ user.email }}</td>
-                    <td>{{ user.first_name }}</td>
-                    <td>{{ user.last_name }}</td>
-                    <td>{{ user.profile.institution }}</td>
-                  </tr>
-                </table>
                 <div class="help-block">
-                    {% blocktrans %}
-                    <strong>If you'd like to add someone else as the PI</strong>, please enter their information here.
-                    The first name will be presented to reviewers as an initial. {{ form.pi.value }}
-                    {% endblocktrans %}
+                    The first name of the principal investigator will be presented to reviewers as an initial.
                 </div>
-                {% endif %}
                 <table class="table">
                   <thead><tr><th>Email</th><th>First Name</th><th>Last Name</th><th>Institution</th></tr></thead>
                   <tr>

--- a/valhalla/sciapplications/views.py
+++ b/valhalla/sciapplications/views.py
@@ -47,6 +47,8 @@ class SciApplicationCreateView(LoginRequiredMixin, CreateView):
 
     def get_initial(self):
         initial = {'call': self.call}
+        # Fill in pi fields with submitter details since that is the most common use case for all forms,
+        # except scicollab forms
         if self.call.proposal_type != Call.COLLAB_PROPOSAL:
             initial['pi'] = self.request.user.email
             initial['pi_first_name'] = self.request.user.first_name

--- a/valhalla/sciapplications/views.py
+++ b/valhalla/sciapplications/views.py
@@ -46,7 +46,13 @@ class SciApplicationCreateView(LoginRequiredMixin, CreateView):
             return reverse('sciapplications:index')
 
     def get_initial(self):
-        return {'call': self.call}
+        initial = {'call': self.call}
+        if self.call.proposal_type != Call.COLLAB_PROPOSAL:
+            initial['pi'] = self.request.user.email
+            initial['pi_first_name'] = self.request.user.first_name
+            initial['pi_last_name'] = self.request.user.last_name
+            initial['pi_institution'] = self.request.user.profile.institution
+        return initial
 
     def get(self, request, *args, **kwargs):
         self.object = None

--- a/valhalla/sciapplications/views.py
+++ b/valhalla/sciapplications/views.py
@@ -158,6 +158,10 @@ class SciApplicationUpdateView(LoginRequiredMixin, UpdateView):
         return HttpResponseRedirect(self.get_success_url())
 
     def forms_invalid(self, forms):
+        # The status is still DRAFT since the form is invalid
+        data = forms['main'].data.copy()
+        data['status'] = ScienceApplication.DRAFT
+        forms['main'].data = data
         return self.render_to_response(
             self.get_context_data(
                 form=forms['main'], timerequest_form=forms['tr'], ci_form=forms['ci'], call=self.object.call


### PR DESCRIPTION
Changes in this pull request:
- Made all PI fields in all sciapplication forms required fields for submission. This simplified some logic. This also means that users can and must fill in their details if they are to be the PI.
- Initialize PI fields with the submitter’s details for all forms except scicollab forms. Scicollab admins are able to set these fields with their own details.