### PR TITLE
added exposure time from slit width calculation in compose page

### DIFF
--- a/static/js/components/molecule.vue
+++ b/static/js/components/molecule.vue
@@ -38,7 +38,7 @@
           <customselect v-if="molecule.type === 'EXPOSE'" v-model="molecule.filter" label="Filter" v-on:input="update"
                          :errors="errors.filter" :options="filterOptions" desc="The filter to be used with this instrument">
           </customselect>
-          <customselect v-if="molecule.type === 'SPECTRUM'" v-model="molecule.spectra_slit" label="Slit Width" v-on:input="update"
+          <customselect v-if="molecule.type === 'SPECTRUM' || molecule.type === 'LAMP_FLAT' || molecule.type === 'ARC'" v-model="molecule.spectra_slit" label="Slit Width" v-on:input="update"
                          :errors="errors.spectra_slit" :options="filterOptions" desc="The width the of the slit to be used.">
           </customselect>
           <customfield v-model="molecule.exposure_count" label="Exposure Count" field="exposure_count" v-on:input="update"
@@ -86,7 +86,7 @@
 <script>
 import _ from 'lodash';
 
-import {collapseMixin} from '../utils.js';
+import {collapseMixin, slitWidthToExposureTime} from '../utils.js';
 import panel from './util/panel.vue';
 import customfield from './util/customfield.vue';
 import customselect from './util/customselect.vue';
@@ -217,6 +217,11 @@ export default {
           this.acquire_params.acquire_radius_arcsec = this.molecule.acquire_radius_arcsec;
           this.molecule.acquire_radius_arcsec = undefined;
         }
+      }
+    },
+    'molecule.spectra_slit': function(value){
+      if(this.molecule.type === 'LAMP_FLAT'){
+        this.molecule.exposure_time = slitWidthToExposureTime(value);
       }
     },
     'molecule.type': function(value){

--- a/static/js/components/request.vue
+++ b/static/js/components/request.vue
@@ -136,6 +136,21 @@ export default {
         return 'IMAGE';
       }
     },
+    slitWidthToExposureTime: function(slitWidth){
+      if(slitWidth.includes('1.2')){
+        return 70;
+      }
+      else if(slitWidth.includes('1.6')){
+        return 50;
+      }
+      else if(slitWidth.includes('2.0')){
+        return 40;
+      }
+      else if(slitWidth.includes('6.0')){
+        return 15;
+      }
+      return 60;
+    },
     updateAcceptabilityThreshold: function(instrument) {
       const floydsDefaultAcceptability = 100;
       const otherDefaultAcceptability = 90;
@@ -173,9 +188,11 @@ export default {
       }
       calibs[0].type = 'LAMP_FLAT'; calibs[1].type = 'ARC';
       calibs[0].ag_mode = 'OPTIONAL'; calibs[1].ag_mode = 'OPTIONAL';
+      calibs[0].exposure_time = this.slitWidthToExposureTime(calibs[0].spectra_slit);
       request.molecules.unshift(calibs[0], calibs[1]);
       calibs[2].type = 'ARC'; calibs[3].type = 'LAMP_FLAT';
       calibs[2].ag_mode = 'OPTIONAL'; calibs[3].ag_mode = 'OPTIONAL';
+      calibs[3].exposure_time = this.slitWidthToExposureTime(calibs[3].spectra_slit);
       request.molecules.push(calibs[2], calibs[3]);
       this.update();
     },

--- a/static/js/components/request.vue
+++ b/static/js/components/request.vue
@@ -56,7 +56,7 @@
 <script>
 import _ from 'lodash';
 
-import {collapseMixin} from '../utils.js';
+import {collapseMixin, slitWidthToExposureTime} from '../utils.js';
 import target from './target.vue';
 import molecule from './molecule.vue';
 import window from './window.vue';
@@ -136,21 +136,6 @@ export default {
         return 'IMAGE';
       }
     },
-    slitWidthToExposureTime: function(slitWidth){
-      if(slitWidth.includes('1.2')){
-        return 70;
-      }
-      else if(slitWidth.includes('1.6')){
-        return 50;
-      }
-      else if(slitWidth.includes('2.0')){
-        return 40;
-      }
-      else if(slitWidth.includes('6.0')){
-        return 15;
-      }
-      return 60;
-    },
     updateAcceptabilityThreshold: function(instrument) {
       const floydsDefaultAcceptability = 100;
       const otherDefaultAcceptability = 90;
@@ -188,11 +173,11 @@ export default {
       }
       calibs[0].type = 'LAMP_FLAT'; calibs[1].type = 'ARC';
       calibs[0].ag_mode = 'OPTIONAL'; calibs[1].ag_mode = 'OPTIONAL';
-      calibs[0].exposure_time = this.slitWidthToExposureTime(calibs[0].spectra_slit);
+      calibs[0].exposure_time = slitWidthToExposureTime(calibs[0].spectra_slit);
       request.molecules.unshift(calibs[0], calibs[1]);
       calibs[2].type = 'ARC'; calibs[3].type = 'LAMP_FLAT';
       calibs[2].ag_mode = 'OPTIONAL'; calibs[3].ag_mode = 'OPTIONAL';
-      calibs[3].exposure_time = this.slitWidthToExposureTime(calibs[3].spectra_slit);
+      calibs[3].exposure_time = slitWidthToExposureTime(calibs[3].spectra_slit);
       request.molecules.push(calibs[2], calibs[3]);
       this.update();
     },

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,5 +1,22 @@
 import moment from 'moment';
 
+function slitWidthToExposureTime(slitWidth){
+  // Lamp flats are affected by the slit width, so exposure time needs to scale with it
+  if(slitWidth.includes('1.2')){
+    return 70;
+  }
+  else if(slitWidth.includes('1.6')){
+    return 50;
+  }
+  else if(slitWidth.includes('2.0')){
+    return 40;
+  }
+  else if(slitWidth.includes('6.0')){
+    return 15;
+  }
+  return 60;
+}
+
 function semesterStart(datetime){
   if(datetime.month() < 3 ){
     return datetime.subtract(1, 'years').month(9).date(1);
@@ -174,6 +191,6 @@ var colorPalette = [  // useful assigning colors to datasets.
 
 export {
   semesterStart, semesterEnd, sexagesimalRaToDecimal, sexagesimalDecToDecimal, QueryString,
-  formatDate, formatField, datetimeFormat, collapseMixin, siteToColor, siteCodeToName,
+  formatDate, formatField, datetimeFormat, collapseMixin, siteToColor, siteCodeToName, slitWidthToExposureTime,
   observatoryCodeToNumber, telescopeCodeToName, colorPalette, julianToModifiedJulian
 };


### PR DESCRIPTION
For story: https://www.pivotaltracker.com/story/show/161856827

Right now it sets the exposure time when first generating the lamp flat calibration blocks. I'm not sure if it should be reset if they generate the lamp flats and then change the slit width afterwards (because they may have manually altered them at that point...)