### PR TITLE
Sinistro readout time hack

### DIFF
--- a/valhalla/common/test_data/configdb.json
+++ b/valhalla/common/test_data/configdb.json
@@ -135,6 +135,34 @@
                 },
                 {
                   "state": "SCHEDULABLE",
+                  "code": "xx07",
+                  "science_camera": {
+                    "camera_type": {
+                      "code": "1M0-SCICAM-SINISTRO",
+                      "name": "1M0-SCICAM-SINISTRO",
+                      "default_mode": {
+                        "binning": 1,
+                        "readout": 37.0
+                      },
+                      "config_change_time": 2,
+                      "acquire_processing_time": 0,
+                      "acquire_exposure_time": 0,
+                      "front_padding": 90,
+                      "filter_change_time": 2,
+                      "fixed_overhead_per_exposure": 1,
+                      "mode_set": [
+                        {
+                          "binning": 1,
+                          "readout": 37.0
+                        }
+                      ]
+                    },
+                    "filters": "air"
+                  },
+                  "__str__": "tst.domb.1m0a.xx07-xx07"
+                },
+                {
+                  "state": "SCHEDULABLE",
                   "code": "nresXX",
                   "science_camera": {
                     "camera_type": {

--- a/valhalla/userrequests/duration_utils.py
+++ b/valhalla/userrequests/duration_utils.py
@@ -50,7 +50,7 @@ def get_molecule_duration_per_exposure(molecule_dict, window_dicts):
     # hack that will be removed after the transition date.
     readout_switch_dt = datetime(year=2019, month=2, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc)
 
-    if any(['start' in w for w in window_dicts]):
+    if any(['start' in w for w in window_dicts]): 
         earliest_window_start = min([w['start'].replace(tzinfo=timezone.utc) for w in window_dicts if 'start' in w])
     else:
         earliest_window_start = timezone.now()

--- a/valhalla/userrequests/duration_utils.py
+++ b/valhalla/userrequests/duration_utils.py
@@ -50,7 +50,7 @@ def get_molecule_duration_per_exposure(molecule_dict, window_dicts):
     # hack that will be removed after the transition date.
     readout_switch_dt = datetime(year=2019, month=2, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc)
 
-    if window_dicts and sum([1 for w in window_dicts if 'start' in w]) > 0:
+    if any(['start' in w for w in window_dicts]):
         earliest_window_start = min([w['start'].replace(tzinfo=timezone.utc) for w in window_dicts if 'start' in w])
     else:
         earliest_window_start = timezone.now()

--- a/valhalla/userrequests/duration_utils.py
+++ b/valhalla/userrequests/duration_utils.py
@@ -1,6 +1,8 @@
 import itertools
 from django.utils.translation import ugettext as _
 from math import ceil, floor
+from datetime import datetime
+from django.utils import timezone
 import logging
 
 from valhalla.proposals.models import TimeAllocationKey, Proposal, Semester
@@ -42,14 +44,28 @@ def get_num_filter_changes(molecules):
     return len(list(itertools.groupby([mol.get('filter', '') for mol in molecules])))
 
 
-def get_molecule_duration_per_exposure(molecule_dict):
-    total_overhead_per_exp = configdb.get_exposure_overhead(molecule_dict['instrument_name'], molecule_dict['bin_x'])
+def get_molecule_duration_per_exposure(molecule_dict, window_dicts):
+    # The artificial delay for sinistro imaging readout will be removed on UT Feb 5 00:00. Use the real (lower) readout
+    # time of 26 seconds for sinistro imager requests whose earliest window starts after this date. This is a
+    # hack that will be removed after the transition date.
+    readout_switch_dt = datetime(year=2019, month=2, day=5, hour=0, minute=0, second=0, tzinfo=timezone.utc)
+
+    if window_dicts and sum([1 for w in window_dicts if 'start' in w]) > 0:
+        earliest_window_start = min([w['start'].replace(tzinfo=timezone.utc) for w in window_dicts if 'start' in w])
+    else:
+        earliest_window_start = timezone.now()
+
+    if molecule_dict['instrument_name'].upper() == '1M0-SCICAM-SINISTRO' and earliest_window_start >= readout_switch_dt:
+        # The get_exposure_overhead method returns the readout time + fixed_overhead_per_exposure (in this case 1s)
+        total_overhead_per_exp = 26 + 1
+    else:
+        total_overhead_per_exp = configdb.get_exposure_overhead(molecule_dict['instrument_name'], molecule_dict['bin_x'])
     mol_duration_per_exp = molecule_dict['exposure_time'] + total_overhead_per_exp
     return mol_duration_per_exp
 
 
-def get_molecule_duration(molecule_dict):
-    mol_duration_per_exp = get_molecule_duration_per_exposure(molecule_dict)
+def get_molecule_duration(molecule_dict, window_dicts):
+    mol_duration_per_exp = get_molecule_duration_per_exposure(molecule_dict, window_dicts)
     mol_duration = molecule_dict['exposure_count'] * mol_duration_per_exp
     duration = mol_duration + PER_MOLECULE_GAP + PER_MOLECULE_STARTUP_TIME
 
@@ -60,7 +76,7 @@ def get_request_duration_dict(request_dict):
     req_durations = {'requests': []}
     for req in request_dict:
         req_info = {'duration': get_request_duration(req)}
-        mol_durations = [{'duration': get_molecule_duration_per_exposure(mol)} for mol in req['molecules']]
+        mol_durations = [{'duration': get_molecule_duration_per_exposure(mol, req['windows'])} for mol in req['molecules']]
         req_info['molecules'] = mol_durations
         req_info['largest_interval'] = get_largest_interval(get_rise_set_intervals(req)).total_seconds()
         req_info['largest_interval'] -= (PER_MOLECULE_STARTUP_TIME + PER_MOLECULE_GAP)
@@ -112,8 +128,8 @@ def get_request_duration_sum(userrequest_dict):
     return duration_sum
 
 
-def get_num_exposures(molecule_dict, time_available):
-    mol_duration_per_exp = get_molecule_duration_per_exposure(molecule_dict)
+def get_num_exposures(molecule_dict, time_available, window_dicts):
+    mol_duration_per_exp = get_molecule_duration_per_exposure(molecule_dict, window_dicts)
     exposure_time = time_available.total_seconds() - PER_MOLECULE_GAP - PER_MOLECULE_STARTUP_TIME
     num_exposures = exposure_time // mol_duration_per_exp
 
@@ -123,7 +139,8 @@ def get_num_exposures(molecule_dict, time_available):
 def get_request_duration(request_dict):
     # calculate the total time needed by the request, based on its instrument and exposures
     request_overheads = configdb.get_request_overheads(request_dict['molecules'][0]['instrument_name'])
-    duration = sum([get_molecule_duration(m) for m in request_dict['molecules']])
+    window_dicts = request_dict['windows'] if 'windows' in request_dict else []
+    duration = sum([get_molecule_duration(m, window_dicts) for m in request_dict['molecules']])
     if configdb.is_spectrograph(request_dict['molecules'][0]['instrument_name']):
         duration += get_num_mol_changes(request_dict['molecules']) * request_overheads['config_change_time']
 

--- a/valhalla/userrequests/models.py
+++ b/valhalla/userrequests/models.py
@@ -151,7 +151,8 @@ class Request(models.Model):
     def duration(self):
         cached_duration = cache.get('request_duration_{}'.format(self.id))
         if not cached_duration:
-            duration = get_request_duration({'molecules': [m.as_dict for m in self.molecules.all()]})
+            duration = get_request_duration({'molecules': [m.as_dict for m in self.molecules.all()],
+                                             'windows': [w.as_dict for w in self.windows.all()]})
             cache.set('request_duration_{}'.format(self.id), duration, 86400 * 30 * 6)
             return duration
         else:
@@ -447,7 +448,7 @@ class Molecule(models.Model):
 
     @cached_property
     def duration(self):
-        return get_molecule_duration(self.as_dict)
+        return get_molecule_duration(self.as_dict, [w.as_dict for w in self.request.windows.all()])
 
 
 class Constraints(models.Model):

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -326,9 +326,9 @@ class RequestSerializer(serializers.ModelSerializer):
 
             for molecule in data['molecules']:
                 if molecule.get('fill_window'):
-                    molecule_duration = get_molecule_duration(molecule_dict=molecule)
+                    molecule_duration = get_molecule_duration(molecule_dict=molecule, window_dicts=data['windows'])
                     num_exposures = get_num_exposures(
-                        molecule, largest_interval - timedelta(seconds=duration - molecule_duration)
+                        molecule, largest_interval - timedelta(seconds=duration - molecule_duration), data['windows']
                     )
                     molecule['exposure_count'] = num_exposures
                     duration = get_request_duration(data)

--- a/valhalla/userrequests/test/test.py
+++ b/valhalla/userrequests/test/test.py
@@ -345,3 +345,45 @@ class TestRequestDuration(ConfigDBTestMixin, SetTimeMixin, TestCase):
         with self.assertRaises(ConfigDBException) as context:
             bad_molecule.duration
             self.assertTrue('not found in configdb' in context.exception)
+
+    def test_archon_sinistro_hack_lowered_sinsitro_duration(self):
+        mixer.blend(
+            Molecule, request=self.request, bin_x=1, bin_y=1, instrument_name='1M0-SCICAM-SINISTRO',
+            exposure_time=30, exposure_count=1, type='EXPOSE', filter='ir'
+        )
+        window_before = mixer.blend(
+            Window, start=datetime(2019, 1, 29, tzinfo=timezone.utc), end=datetime(2019, 2, 20, tzinfo=timezone.utc)
+        )
+        window_after = mixer.blend(
+            Window, start=datetime(2019, 2, 6, tzinfo=timezone.utc), end=datetime(2019, 2, 20, tzinfo=timezone.utc)
+        )
+        self.request.windows.set([window_after])
+        self.request.save()
+        duration_after = self.request.duration
+        # Clear out the request cached property duration so that it can be recalculated
+        del self.request.duration
+        self.request.windows.set([window_before])
+        self.request.save()
+        duration_before = self.request.duration
+        self.assertTrue(duration_after < duration_before)
+
+    def test_archon_sinistro_hack_didnt_affect_sbig(self):
+        mixer.blend(
+            Molecule, request=self.request, bin_x=1, bin_y=1, instrument_name='1M0-SCICAM-SBIG',
+            exposure_time=30, exposure_count=1, type='EXPOSE', filter='ir'
+        )
+        window_before = mixer.blend(
+            Window, start=datetime(2019, 1, 29, tzinfo=timezone.utc), end=datetime(2019, 2, 20, tzinfo=timezone.utc)
+        )
+        window_after = mixer.blend(
+            Window, start=datetime(2019, 2, 6, tzinfo=timezone.utc), end=datetime(2019, 2, 20, tzinfo=timezone.utc)
+        )
+        self.request.windows.set([window_after])
+        self.request.save()
+        duration_after = self.request.duration
+        # Clear out the request cached property duration so that it can be recalculated
+        del self.request.duration
+        self.request.windows.set([window_before])
+        self.request.save()
+        duration_before = self.request.duration
+        self.assertEqual(duration_after, duration_before)

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -373,6 +373,50 @@ class TestUserPostRequestApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()['requests'][0]['acceptability_threshold'], 100)
 
+    @patch('valhalla.userrequests.duration_utils.get_semesters')
+    def test_post_userrequest_sinistro_archon_readout_hack(self, mock_get_semesters):
+        # Add the semester in which the hack applies
+        another_semester = mixer.blend(
+            Semester,
+            id='2019A',
+            start=datetime(2018, 12, 1, tzinfo=timezone.utc),
+            end=datetime(2019, 6, 30, tzinfo=timezone.utc),
+        )
+        mock_get_semesters.return_value = [self.semester, another_semester]
+        # Need some time allocations for the new semester
+        mixer.blend(
+            TimeAllocation, proposal=self.proposal, semester=another_semester,
+            telescope_class='1m0', instrument_name='1M0-SCICAM-SBIG', std_allocation=100.0, std_time_used=0.0,
+            too_allocation=10, too_time_used=0.0, ipp_limit=10.0, ipp_time_available=5.0
+        )
+        mixer.blend(
+            TimeAllocation, proposal=self.proposal, semester=another_semester,
+            telescope_class='1m0', instrument_name='1M0-SCICAM-SINISTRO', std_allocation=100.0, std_time_used=0.0,
+            too_allocation=10, too_time_used=0.0, ipp_limit=10.0, ipp_time_available=5.0
+        )
+        data = self.generic_payload.copy()
+        # Data mods that are used in all subsequent checks
+        data['requests'][0]['windows'][0]['end'] = '2019-06-07T21:12:18Z'
+        data['requests'][0]['target']['ra'] = 187
+        data['requests'][0]['target']['dec'] = 14
+        # Test that the duration remains the same for an SBIG before and after the transition date
+        data['requests'][0]['windows'][0]['start'] = '2019-01-25T21:12:18Z'
+        sbig_response_before = self.client.post(reverse('api:user_requests-list'), data=data)
+        data['requests'][0]['windows'][0]['start'] = '2019-02-05T00:00:00Z'
+        sbig_response_after = self.client.post(reverse('api:user_requests-list'), data=data)
+        self.assertEqual(sbig_response_before.status_code, 201)
+        self.assertEqual(sbig_response_after.status_code, 201)
+        self.assertEqual(sbig_response_before.json()['requests'][0]['duration'], sbig_response_after.json()['requests'][0]['duration'])
+        # Test that the duration decreases for a sinistro after the transition date
+        data['requests'][0]['molecules'][0]['instrument_name'] = '1M0-SCICAM-SINISTRO'
+        data['requests'][0]['windows'][0]['start'] = '2019-01-25T21:12:18Z'
+        sinistro_response_before = self.client.post(reverse('api:user_requests-list'), data=data)
+        data['requests'][0]['windows'][0]['start'] = '2019-02-05T00:00:00Z'
+        sinistro_response_after = self.client.post(reverse('api:user_requests-list'), data=data)
+        self.assertEqual(sinistro_response_after.status_code, 201)
+        self.assertEqual(sinistro_response_before.status_code, 201)
+        self.assertTrue(sinistro_response_before.json()['requests'][0]['duration'] > sinistro_response_after.json()['requests'][0]['duration'])
+
 
 class TestDisallowedMethods(APITestCase):
     def setUp(self):


### PR DESCRIPTION
This PR uses a 26 second readout time in overhead calculations for sinisitro requests where windows start after the transition date of UT Feb 5 2019 00:00. All of this will be reverted after the transition.