### PR TITLE
Make Observing Portal IPP error message grammatically correct and a little more user friendly.

### DIFF
--- a/valhalla/userrequests/state_changes.py
+++ b/valhalla/userrequests/state_changes.py
@@ -92,12 +92,11 @@ def validate_ipp(ur_dict, total_duration_dict):
         if time_allocations_dict[tak] < (duration_hours * ipp_value):
             max_ipp_allowable = (time_allocations_dict[tak] / duration_hours) + 1.0
             truncated_max_ipp_allowable = floor(max_ipp_allowable * 1000.0) / 1000.0
-            msg = _(("{}-{}'{}' ipp_value of {} requires more ipp_time then is available. "
-                     "Please lower your ipp_value to <= {} and submit again.")).format(
-                tak.telescope_class,
-                tak.instrument_name,
-                ur_dict['observation_type'],
+            msg = _(("An IPP Value of {} requires more IPP time than you have available for '{}' Observation with the {} . "
+                     "Please lower your IPP Value to <= {} and submit again.")).format(
                 (ipp_value + 1),
+                ur_dict['observation_type'],
+                tak.instrument_name,
                 truncated_max_ipp_allowable
             )
             raise TimeAllocationError(msg)

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -528,7 +528,6 @@ class TestUserRequestIPP(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         response = self.client.post(reverse('api:user_requests-list'), data=ur)
         self.assertEqual(response.status_code, 400)
         self.assertIn('TimeAllocationError', str(response.content))
-        print(str(response.content))
         self.assertIn('An IPP Value of 100.0 requires more IPP time than you have available', str(response.content))
 
         # verify that objects were not created by the send

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -528,7 +528,8 @@ class TestUserRequestIPP(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         response = self.client.post(reverse('api:user_requests-list'), data=ur)
         self.assertEqual(response.status_code, 400)
         self.assertIn('TimeAllocationError', str(response.content))
-        self.assertIn('ipp_value of 100.0 requires more ipp_time then is available.', str(response.content))
+        print(str(response.content))
+        self.assertIn('An IPP Value of 100.0 requires more IPP time than you have available', str(response.content))
 
         # verify that objects were not created by the send
         self.assertFalse(UserRequest.objects.filter(group_id='ipp_request').exists())


### PR DESCRIPTION
There's a typo in the error message when you put in an incorrect IPP value.
It also looks way to much like a stack trace to be on a public facing website.
It still looks like a stack trace, but it might be a bit more readable now for the average user.