### PR TITLE
Feature/dual coordinate display

### DIFF
--- a/static/js/components/target.vue
+++ b/static/js/components/target.vue
@@ -146,10 +146,10 @@ export default {
       ns_target_params: ns_target_params,
       sid_target_params: sid_target_params,
       rot_target_params: rot_target_params,
-      ra_display: '',
-      dec_display: '',
-      ra_help_text: '',
-      dec_help_text: ''
+      ra_display: this.target.ra,
+      dec_display: this.target.dec,
+      ra_help_text: this.raHelp(this.target.ra),
+      dec_help_text: this.decHelp(this.target.dec)
     };
   },
   methods: {
@@ -158,21 +158,27 @@ export default {
     },
     updateRA: function(){
       this.target.ra = sexagesimalRaToDecimal(this.ra_display);
-      if(isNaN(Number(this.ra_display))) {
-        this.ra_help_text = 'Decimal: ' + Number(sexagesimalRaToDecimal(this.ra_display));
-      } else {
-        this.ra_help_text = 'Sexigesimal: ' + decimalRaToSexigesimal(this.ra_display).str;
-      }
+      this.ra_help_text = this.raHelp(this.ra_display);
       this.update();
     },
     updateDec: function(){
       this.target.dec = sexagesimalDecToDecimal(this.dec_display);
-      if(isNaN(Number(this.dec_display))) {
-        this.dec_help_text = 'Decimal: ' + Number(sexagesimalDecToDecimal(this.dec_display));
-      } else {
-        this.dec_help_text = 'Sexigesimal: ' + decimalDecToSexigesimal(this.dec_display).str;
-      }
+      this.dec_help_text = this.decHelp(this.dec_display);
       this.update();
+    },
+    raHelp: function(ra){
+      if(isNaN(Number(ra))) {
+        return 'Decimal: ' + Number(sexagesimalRaToDecimal(ra));
+      } else {
+        return 'Sexigesimal: ' + decimalRaToSexigesimal(ra).str;
+      }
+    },
+    decHelp: function(dec){
+      if(isNaN(Number(dec))) {
+        return 'Decimal: ' + Number(sexagesimalDecToDecimal(dec));
+      } else {
+        return 'Sexigesimal: ' + decimalDecToSexigesimal(dec).str;
+      }
     }
   },
   watch: {

--- a/static/js/request_detail.vue
+++ b/static/js/request_detail.vue
@@ -55,11 +55,13 @@
           <div class="col-md-6">
             <h4>Target</h4>
             <dl class="twocol dl-horizontal">
-              <span v-for="x, idx in request.target">
+              <span class="nobreak" v-for="x, idx in request.target">
               <dt v-if="request.target[idx]">{{ idx | formatField }}</dt>
               <dd v-if="x">
                 <span v-if="idx === 'name'">{{ x }}</span>
                 <span v-else>{{ x | formatValue }}</span>
+                <em v-if="idx === 'ra'" class="text-muted">{{ x | rAAsSexigesimal }}</em>
+                <em v-if="idx === 'dec'" class="text-muted">{{ x | decAsSexigesimal }}</em>
               </dd>
               </span>
             </dl>
@@ -115,7 +117,7 @@ import thumbnail from './components/thumbnail.vue';
 import archivetable from './components/archivetable.vue';
 import blockhistory from './components/blockhistory.vue';
 import airmass_telescope_states from './components/airmass_telescope_states.vue';
-import {formatDate, formatField} from './utils.js';
+import {formatDate, formatField, decimalDecToSexigesimal, decimalRaToSexigesimal} from './utils.js';
 import {login, getLatestFrame} from './archive.js';
 
 Vue.filter('formatDate', function(value){
@@ -131,6 +133,14 @@ Vue.filter('formatValue', function(value){
     return Number(value).toFixed(4);
   }
   return value;
+});
+
+Vue.filter('rAAsSexigesimal', function(ra){
+  return decimalRaToSexigesimal(ra).str
+});
+
+Vue.filter('decAsSexigesimal', function(dec){
+  return decimalDecToSexigesimal(dec).str
 });
 
 export default {
@@ -275,5 +285,8 @@ dl.twocol dd {
 }
 .tab-pane {
   padding-top: 5px;
+}
+.nobreak{
+ display: inline-block;
 }
 </style>

--- a/static/js/request_detail.vue
+++ b/static/js/request_detail.vue
@@ -60,7 +60,7 @@
               <dd v-if="x">
                 <span v-if="idx === 'name'">{{ x }}</span>
                 <span v-else>{{ x | formatValue }}</span>
-                <em v-if="idx === 'ra'" class="text-muted">{{ x | rAAsSexigesimal }}</em>
+                <em v-if="idx === 'ra'" class="text-muted">{{ x | raAsSexigesimal }}</em>
                 <em v-if="idx === 'dec'" class="text-muted">{{ x | decAsSexigesimal }}</em>
               </dd>
               </span>
@@ -135,7 +135,7 @@ Vue.filter('formatValue', function(value){
   return value;
 });
 
-Vue.filter('rAAsSexigesimal', function(ra){
+Vue.filter('raAsSexigesimal', function(ra){
   return decimalRaToSexigesimal(ra).str
 });
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -84,7 +84,10 @@ function decimalRaToSexigesimal(deg){
   var raM = Math.floor(((ra / 15) - raH) * 60)
   var raS = ((((ra / 15 ) - raH ) * 60) - raM) * 60
   return {
-    'h': raH * rs, 'm': raM, 's': raS, 'str': (rs > 0 ? '' : '-') + raH + ':' + raM + ':' + raS.toFixed(4)
+    'h': raH * rs,
+    'm': raM,
+    's': raS,
+    'str': (rs > 0 ? '' : '-') + zPadFloat(raH) + ':' + zPadFloat(raM) + ':' + zPadFloat(raS)
   }
 }
 
@@ -92,15 +95,18 @@ function decimalDecToSexigesimal(deg){
   var ds = 1;
   if(deg < 0){
     ds = -1;
-    dec = Math.abs(deg);
+    var dec = Math.abs(deg);
   } else {
-    dec = deg;
+    var dec = deg;
   }
-  deg = Math.floor(dec)
-  decM = Math.abs(Math.floor((dec - deg) * 60));
-  decS = (Math.abs((dec - deg) * 60) - decM) * 60
+  var deg = Math.floor(dec)
+  var decM = Math.abs(Math.floor((dec - deg) * 60));
+  var decS = (Math.abs((dec - deg) * 60) - decM) * 60
   return {
-    'deg': deg * ds, 'm': decM, 's': decS, 'str': (ds > 0 ? '' : '-') + deg + ':' + decM + ':' + decS.toFixed(4)
+    'deg': deg * ds,
+    'm': decM,
+    's': decS,
+    'str': (ds > 0 ? '' : '-') + zPadFloat(deg) + ':' + zPadFloat(decM) + ':' + zPadFloat(decS)
   }
 }
 
@@ -120,6 +126,10 @@ function QueryString() {
     }
   }
   return qString;
+}
+
+function zPadFloat(num){
+  return num.toLocaleString(undefined, {'minimumIntegerDigits': 2, 'maximumFractionDigits': 4})
 }
 
 function formatDate(date){
@@ -225,5 +235,5 @@ export {
   semesterStart, semesterEnd, sexagesimalRaToDecimal, sexagesimalDecToDecimal, QueryString,
   formatDate, formatField, datetimeFormat, collapseMixin, siteToColor, siteCodeToName, slitWidthToExposureTime,
   observatoryCodeToNumber, telescopeCodeToName, colorPalette, julianToModifiedJulian,
-  degreesToHMS
+  decimalRaToSexigesimal, decimalDecToSexigesimal
 };

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -72,6 +72,38 @@ function sexagesimalDecToDecimal(dec){
   return dec;
 }
 
+function decimalRaToSexigesimal(deg){
+  var rs = 1;
+  if(deg < 0){
+    rs = -1;
+    var ra = Math.abs(deg);
+  } else {
+    var ra = deg
+  }
+  var raH = Math.floor(ra / 15)
+  var raM = Math.floor(((ra / 15) - raH) * 60)
+  var raS = ((((ra / 15 ) - raH ) * 60) - raM) * 60
+  return {
+    'h': raH * rs, 'm': raM, 's': raS, 'str': (rs > 0 ? '' : '-') + raH + ':' + raM + ':' + raS.toFixed(4)
+  }
+}
+
+function decimalDecToSexigesimal(deg){
+  var ds = 1;
+  if(deg < 0){
+    ds = -1;
+    dec = Math.abs(deg);
+  } else {
+    dec = deg;
+  }
+  deg = Math.floor(dec)
+  decM = Math.abs(Math.floor((dec - deg) * 60));
+  decS = (Math.abs((dec - deg) * 60) - decM) * 60
+  return {
+    'deg': deg * ds, 'm': decM, 's': decS, 'str': (ds > 0 ? '' : '-') + deg + ':' + decM + ':' + decS.toFixed(4)
+  }
+}
+
 function QueryString() {
   var qString = {};
   var query = window.location.search.substring(1);
@@ -192,5 +224,6 @@ var colorPalette = [  // useful assigning colors to datasets.
 export {
   semesterStart, semesterEnd, sexagesimalRaToDecimal, sexagesimalDecToDecimal, QueryString,
   formatDate, formatField, datetimeFormat, collapseMixin, siteToColor, siteCodeToName, slitWidthToExposureTime,
-  observatoryCodeToNumber, telescopeCodeToName, colorPalette, julianToModifiedJulian
+  observatoryCodeToNumber, telescopeCodeToName, colorPalette, julianToModifiedJulian,
+  degreesToHMS
 };


### PR DESCRIPTION
Compose page:
Accept RA/Dec as either decimal or sexigesimal and display the opposite format as help text underneath the input field. No longer automatically converts the user's input. Still sends decimal to the backend.

Detail page:
Show RA/Dec as decimal as before but also show sexigesimal directly underneath it.

Can't think of anywhere else we display coordinates, let me know if I forgot something.