### PR TITLE
add days to submit confirmation message

### DIFF
--- a/static/js/compose.vue
+++ b/static/js/compose.vue
@@ -202,7 +202,7 @@
         var duration = moment.duration(this.duration_data.duration, 'seconds');
         var duration_string = '';
         if(duration.days() > 0){
-            duration_string = duration.days() + ' days ' + duration_string;
+            duration_string = duration.days() + ' days, ' + duration_string;
         }
         if(duration.hours() > 0){
           duration_string += duration.hours() + ' hours, ';

--- a/static/js/compose.vue
+++ b/static/js/compose.vue
@@ -201,6 +201,9 @@
       submit: function(){
         var duration = moment.duration(this.duration_data.duration, 'seconds');
         var duration_string = '';
+        if(duration.days() > 0){
+            duration_string = duration.days() + ' days ' + duration_string;
+        }
         if(duration.hours() > 0){
           duration_string += duration.hours() + ' hours, ';
         }


### PR DESCRIPTION
When submitting a particularly long user request that takes more than 24 hours of time, the `days` portion is truncated from the confirmation warning pop-up message. (It does still appear on the main page.) 

I believe this would fix that so the time shown in the confirmation message will be accurate.