### PR TITLE
let AUTO_FOCUS molecules through for spectrographs

### DIFF
--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -135,8 +135,8 @@ class MoleculeSerializer(serializers.ModelSerializer):
         else:
             raise serializers.ValidationError(_("Missing one of bin_x or bin_y. Specify both or neither."))
 
-        # check that the molecule type matches the instruemnt
-        imager_only_types = ['EXPOSE', 'SKY_FLAT', 'AUTO_FOCUS']
+        # check that the molecule type matches the instrument
+        imager_only_types = ['EXPOSE', 'SKY_FLAT']
         spec_only_types = ['SPECTRUM', 'ARC', 'LAMP_FLAT']
         if configdb.is_spectrograph(data['instrument_name']) and data['type'] in imager_only_types:
             raise serializers.ValidationError(


### PR DESCRIPTION
this is a result of changing the auto_focus molecules
from type SCRIPT to AUTO_FOCUS (and having site-software
understand the args key as the name of the script).