### PR TITLE
Feature/rapid response lifetime

### DIFF
--- a/static/js/components/userrequest.vue
+++ b/static/js/components/userrequest.vue
@@ -179,7 +179,7 @@ export default {
         for (var windowIndex = 0; windowIndex < this.userrequest.requests[index].windows.length; ++windowIndex) {
           if (value === 'TARGET_OF_OPPORTUNITY'){
             delete this.userrequest.requests[index].windows[windowIndex].start;
-            this.userrequest.requests[index].windows[windowIndex].end = moment.utc().add('hours', 6).format(datetimeFormat);
+            this.userrequest.requests[index].windows[windowIndex].end = moment.utc().add('hours', 24).format(datetimeFormat);
           }
           else{
             if (!('start' in this.userrequest.requests[index].windows[windowIndex])) {

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -474,7 +474,10 @@ class UserRequestSerializer(serializers.ModelSerializer):
                                 )
                             if window.get('end') - timezone.now() > timedelta(seconds=(duration + 86400)):
                                 raise serializers.ValidationError(
-                                    _("The Rapid Response observation window must be within the next 24 hours.")
+                                    _(
+                                        "A Rapid Response observation must start within the next 24 hours, so the "
+                                        "window end time must be within the next (24 hours + the observation duration)"
+                                    )
                                 )
 
                 if time_available <= 0.0:

--- a/valhalla/userrequests/serializers.py
+++ b/valhalla/userrequests/serializers.py
@@ -464,7 +464,7 @@ class UserRequestSerializer(serializers.ModelSerializer):
                 elif data['observation_type'] == UserRequest.TOO:
                     time_available = time_allocation.too_allocation - time_allocation.too_time_used
                     # For Rapid Response observations, check if the end time of the window is within
-                    # six hours + the duration of the observation
+                    # 24 hours + the duration of the observation
                     for request in data['requests']:
                         windows = request.get('windows')
                         for window in windows:
@@ -472,9 +472,9 @@ class UserRequestSerializer(serializers.ModelSerializer):
                                 raise serializers.ValidationError(
                                     _("The Rapid Response observation window start time cannot be in the future.")
                                 )
-                            if window.get('end') - timezone.now() > timedelta(seconds=(duration + 21600)):
+                            if window.get('end') - timezone.now() > timedelta(seconds=(duration + 86400)):
                                 raise serializers.ValidationError(
-                                    _("The Rapid Response observation window must be within the next six hours.")
+                                    _("The Rapid Response observation window must be within the next 24 hours.")
                                 )
 
                 if time_available <= 0.0:

--- a/valhalla/userrequests/test/test_api.py
+++ b/valhalla/userrequests/test/test_api.py
@@ -233,22 +233,22 @@ class TestUserPostRequestApi(ConfigDBTestMixin, SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('cannot be in the future.', str(response.content))
 
-    def test_post_userrequest_too_within_six_hours(self):
+    def test_post_userrequest_too_within_24_hours(self):
         data = self.generic_payload.copy()
         data['observation_type'] = UserRequest.TOO
         data['requests'][0]['windows'][0]['start'] = timezone.now() + timedelta(0)
-        data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 18000)
+        data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 82800)  # 23 hours
         response = self.client.post(reverse('api:user_requests-list'), data=data)
         self.assertEqual(response.status_code, 201)
 
-    def test_post_userrequest_too_not_within_six_hours(self):
+    def test_post_userrequest_too_not_within_24_hours(self):
         bad_data = self.generic_payload.copy()
         bad_data['observation_type'] = UserRequest.TOO
         bad_data['requests'][0]['windows'][0]['start'] = timezone.now() + timedelta(0)
-        bad_data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 25200)
+        bad_data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 90000)  # 25 hours
         response = self.client.post(reverse('api:user_requests-list'), data=bad_data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn('must be within the next six hours.', str(response.content))
+        self.assertIn('must start within the next 24 hours', str(response.content))
 
     def test_post_userrequest_not_have_any_time_left(self):
         bad_data = self.generic_payload.copy()


### PR DESCRIPTION
Rapid response observation window end times were limited to be within the next 6 hours in the future, this PR increases that limit to be within 24 hours in the future. 

This branch is currently running in dev if you want to check it out.