### PR TITLE
Add downtime announcement to homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,11 @@
 {% block title %}Home{% endblock %}
 {% block content %}
 <div class="row">
+    <div class="alert alert-warning" role="alert">
+        <i class="fa fa-exclamation-circle" aria-hidden="true"></i> The observing portal will be down for several hours
+        starting on June 25th at 17 UT for some planned upgrades. You will not be able to submit any observation
+        requests during the downtime.
+    </div>
     <div class="col-md-8">
     {% if not user.is_authenticated and page_obj.number < 2 %}
     <div class="jumbotron noauth">


### PR DESCRIPTION
The announcement looks like this:

![downtime-announcement](https://user-images.githubusercontent.com/8227676/59871166-6e7b8400-9386-11e9-8b9f-73f67cb933e5.png)
